### PR TITLE
Missing repo for com.google.closure-stylesheets:closure-stylesheets:jar:...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,6 @@
 
     <repositories>
         <repository>
-            <id>site</id>
-            <url>http://gwtquery.googlecode.com/svn/mavenrepo</url>
-        </repository>
-        <repository>
             <id>gwtquery-plugins</id>
             <url>http://gwtquery-plugins.googlecode.com/svn/mavenrepo</url>
         </repository>


### PR DESCRIPTION
...v20131127

Fixes the failing `mvn clean install`
