### PR TITLE
Update GWT dependency to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <target.jdk>1.6</target.jdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <gwt.version>2.6.0-rc3</gwt.version>
+        <gwt.version>2.6.0</gwt.version>
         <guava.version>15.0</guava.version>
         <closure.version>v20131127</closure.version>
     </properties>


### PR DESCRIPTION
Now that GWT 2.6.0 is released, it should be used instead of the RC version
