### PR TITLE
GssResource type should map to .css files as well as .gss

### DIFF
--- a/src/main/java/com/google/gwt/resources/client/GssResource.java
+++ b/src/main/java/com/google/gwt/resources/client/GssResource.java
@@ -20,7 +20,7 @@ import com.google.gwt.resources.ext.DefaultExtensions;
 import com.google.gwt.resources.ext.ResourceGeneratorType;
 import com.google.gwt.resources.rg.GssResourceGenerator;
 
-@DefaultExtensions(value = {".gss"})
+@DefaultExtensions(value = {".gss", ".css"})
 @ResourceGeneratorType(GssResourceGenerator.class)
 public interface GssResource extends CssResource {
 }


### PR DESCRIPTION
This will make it easier for teams to migrate, as they can just change the type in the ClientBundle. This will not prevent CssResource from mapping to .css files.
